### PR TITLE
Update etkdg.py for python 3.x

### DIFF
--- a/etkdg.py
+++ b/etkdg.py
@@ -38,9 +38,9 @@ def generate(opts):
     m = Chem.AddHs(m)
     AllChem.EmbedMolecule(m, AllChem.ETKDGv3())
 
-    if opts['ff'] is 'UFF':
+    if opts['ff'] == 'UFF':
         AllChem.UFFOptimizeMolecule(m)
-    elif opts['ff'] is 'MMFF94':
+    elif opts['ff'] == 'MMFF94':
         AllChem.MMFFOptimizeMolecule(m)
 
     return Chem.MolToMolBlock(m)


### PR DESCRIPTION
Avogadro2 1.95.1 on Ubuntu 20.04, python 3.10.1.

On startup, error SyntaxWarning: "is" with a literal. Did you mean "=="?

Lines 41 and 43 changed, works.